### PR TITLE
support StringViews 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [compat]
 Downloads = "1.6.0"
-StringViews = "1.3.4, 1"
+StringViews = "1.3.4, 2"
 StyledStrings = "1.11.0"
 julia = "1.10.8"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [compat]
 Downloads = "1.6.0"
-StringViews = "1.3.4"
+StringViews = "1.3.4, 1"
 StyledStrings = "1.11.0"
 julia = "1.10.8"
 

--- a/src/TokenIterators.jl
+++ b/src/TokenIterators.jl
@@ -14,7 +14,11 @@ Token(data::AbstractVector{UInt8}, kind=nothing) = Token(data, kind, 1, 0)
 Token(s::AbstractString, args...) = Token(codeunits(s), args...)
 
 Base.view(t::Token) = view(t.data, t.i:t.j)
-StringViews.StringView(t::Token) = StringView(view(t))
+if isdefined(Base, :StringView) # merged in Julia 1.14
+    Base.StringView(t::Token) = StringView(view(t))
+else
+    StringViews.StringView(t::Token) = StringView(view(t))
+end
 Base.length(t::Token) = t.j - t.i + 1
 Base.size(t::Token) = (length(t),)
 Base.getindex(t::Token, i::Integer) = view(t)[i]


### PR DESCRIPTION
Updates the package to use StringViews 2.0 if available (which has minor breaking changes with 1.0 that shouldn't affect this package).  In Julia 1.14, where the StringView type is merged into Base, the StringViews 2.0 package becomes a simple stub around the Base type.